### PR TITLE
Be more explicit about label style

### DIFF
--- a/lib/input-color.less
+++ b/lib/input-color.less
@@ -173,6 +173,8 @@
 
     .label {
       font-size: 13px;
+      font-weight: normal;
+      color: #000;
     }
 
     .value {


### PR DESCRIPTION
This is a temporary fix for #11 - by making the font style more explicit it avoids falling back to the global `.label` CSS class when using Bootstrap.

@wangzuo 