### PR TITLE
Fix for Issue #57: Attempt to change hex code by typing results in #2NanNanNan

### DIFF
--- a/src/color-picker.js
+++ b/src/color-picker.js
@@ -11,11 +11,12 @@ import {
   hsv2rgb,
 } from '@swiftcarrot/color-fns';
 import { rgba2hex } from './utils';
+import { useEffect, useState } from 'react';
 
 const KEY_ENTER = 13;
 
 const ColorPicker = ({ color, onChange, disabled }) => {
-  const { r, g, b, a, h, s, v } = color;
+  const { r, g, b, a, h, s, v, hex } = color;
 
   function changeColor(color) {
     if (onChange) {
@@ -44,9 +45,15 @@ const ColorPicker = ({ color, onChange, disabled }) => {
   }
 
   function changeHex(hex) {
+
+    const hexRegx = /^#(?:[0-9A-F]{3}|[0-9A-F]{6}|[0-9A-F]{8})$/i
     const { r, g, b } = hex2rgb(hex);
     const { h, s, v } = rgb2hsv(r, g, b);
-    changeColor({ ...color, r, g, b, h, s, v, hex });
+
+    if(hexRegx.test(hex)) {
+      changeColor({ ...color, r, g, b, h, s, v, hex });
+    }
+
   }
 
   function handleHexKeyUp(e) {
@@ -67,6 +74,14 @@ const ColorPicker = ({ color, onChange, disabled }) => {
   const rgba100 = rgba(r, g, b, 100);
   const opacityGradient = `linear-gradient(to right, ${rgba0}, ${rgba100})`;
   const hueBackground = hsv2hex(h, 100, 100);
+
+  const [hexInput, setHexInput] = useState(hex)
+
+  //reset hexInput if hex value is changed through another UI interaction
+  useEffect(() => {
+    setHexInput(hex)
+  },[hex])
+
 
   return (
     <div css={styles.picker} onClick={handleClick}>
@@ -163,8 +178,11 @@ const ColorPicker = ({ color, onChange, disabled }) => {
           <input
             style={{ width: 70, textAlign: 'left' }}
             type="text"
-            value={color.hex}
-            onChange={(e) => changeHex(e.target.value)}
+            value={hexInput}
+            onChange={(e) => setHexInput(e.target.value)}
+            onBlur={() => {
+              changeHex(hexInput)
+            }}
             onKeyUp={handleHexKeyUp}
             disabled={disabled}
           />

--- a/src/color-picker.js
+++ b/src/color-picker.js
@@ -58,9 +58,8 @@ const ColorPicker = ({ color, onChange, disabled }) => {
 
   function handleHexKeyUp(e) {
     if (e.keyCode === KEY_ENTER) {
-      const hex = e.target.value.trim();
-      const { r, g, b } = hex2rgb(hex);
-      changeColor({ ...color, r, g, b, a, hex });
+      const hex = hexInput.trim();
+      changeHex(hex)
     }
   }
 


### PR DESCRIPTION
Addresses #57. Changes the behaviour for the hex input so that the hex value will only change if the user tabs away from the input or if the user presses the enter key.

Added a local `hexInput` state that stores the input value for the hex text input. `hexInput` value also gets updated in a useEffect hook whenever the parent hex value changes.

Updating the parent hex value is moved to onBlur and OnKeyUp. A regex check was added to `changeHex` to ensure `changeColor` is only called if the hex value is valid. 